### PR TITLE
Set up the notebook state cache for the export action

### DIFF
--- a/.github/workflows/ExportPluto.yaml
+++ b/.github/workflows/ExportPluto.yaml
@@ -32,7 +32,7 @@ jobs:
 
             # We set up a folder that Pluto can use to cache exported notebooks. If the notebook file did not change, then Pluto can take the exported file from cache instead of running the notebook.
             - name: Set up notebook state cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: pluto_state_cache
                   key: ${{ runner.os }}-pluto_state_cache-v2-${{ hashFiles('**/Project.toml', '**/Manifest.toml', '.github/workflows/*' ) }}-${{ hashFiles('**/*jl') }}
@@ -48,7 +48,7 @@ jobs:
                   
                   import PlutoSliderServer
 
-                  PlutoSliderServer.github_action(".")'
+                  PlutoSliderServer.github_action("."; Export_cache_dir="pluto_state_cache")'
 
 
             - name: Deploy to gh-pages


### PR DESCRIPTION
This will make sure that only changed notebook files are re-generated on commit.